### PR TITLE
update requirements.txt to install dateutil or python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 requests
 datetime
-dateutil
 numpy
+python-dateutil; python_version >= '3'
+dateutil; python_version < '3'


### PR DESCRIPTION
Still new to all this. 

I think my change works for installing the correct version of dateutil for python version used. 

And I think I created this pull request correctly. 